### PR TITLE
Feat: Add 'extra' argument to insertInto and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 - [Debug Mode & Logging](#debug-mode--logging)
 - [Type Conversion](#type-conversion)
 - [Known Restrictions](#known-restrictions)
+- [Contributors](#contributors)
+- [LICENSE](#license)
 
 ## Installation
 
@@ -180,6 +182,12 @@ const userObject: User = {user_id: "12345", username: "lucemans"};
 await DB.insertInto('users', userObject);
 ```
 
+Adding extra values to this query should be as simple as
+
+```ts
+await DB.insertInto('users', {user_id: "12345", username: "lucemans"}, "ALLOW FILTERING");
+```
+
 ### deleteFrom
 
 Deleting fromt he database can be done in a multitude of ways. In the event of deleting the entire row from the table, you can do it like so:
@@ -196,12 +204,24 @@ In the event you want to simply delete/clear one of the cells in a specific row 
 await DB.deleteFrom('users', ['username'], {user_id: "12345"});
 ```
 
+Adding extra values to this query should be as simple as
+
+```ts
+await DB.deleteFrom('users', ['username'], {user_id: "12345"}, "ALLOW FILTERING");
+```
+
 ### update
 
 Update allows you to edit only some parts of a row. This is done by passing an object with the values you want to update and the criteria to find the row you want to update.
 
 ```ts
 await DB.update('users', {username: "lucemans"}, {user_id: "12345"})
+```
+
+Adding extra values to this query should be as simple as
+
+```ts
+await DB.update('users', {username: "lucemans"}, {user_id: "12345"}, "ALLOW FILTERING");
 ```
 
 ### createTable

--- a/__tests__/raw/deleteFromRaw.spec.ts
+++ b/__tests__/raw/deleteFromRaw.spec.ts
@@ -4,3 +4,7 @@ import { selectOneFromRaw } from "../../lib";
 it('Can insert a user into the database', async () => {
     expect(selectOneFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1234567890, username: 'Jest'})).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? LIMIT 1', args: [1234567890, 'Jest']});
 });
+
+it('Can add extra args to query', async () => {
+    expect(selectOneFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1234567890, username: 'Jest'}, "ALLOW FILTERING")).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? LIMIT 1 ALLOW FILTERING', args: [1234567890, 'Jest']});
+});

--- a/__tests__/raw/insertIntoRaw.spec.ts
+++ b/__tests__/raw/insertIntoRaw.spec.ts
@@ -4,3 +4,8 @@ import { selectOneFromRaw } from "../../lib";
 it('Can insert a user into the database', async () => {
     expect(selectOneFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1234567890, username: 'Jest'})).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? LIMIT 1', args: [1234567890, 'Jest']});
 });
+
+
+it('Can add extra args to query', async () => {
+    expect(selectOneFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1234567890, username: 'Jest'}, 'ALLOW FILTERING')).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? LIMIT 1 ALLOW FILTERING', args: [1234567890, 'Jest']});
+});

--- a/__tests__/raw/selectFromRaw.spec.ts
+++ b/__tests__/raw/selectFromRaw.spec.ts
@@ -1,0 +1,11 @@
+import { selectFromRaw } from '../../lib';
+
+// fix
+it('Can insert a user into the database', async () => {
+    expect(selectFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1, username: 'svemat'})).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=?', args: [1, 'svemat']});
+});
+
+
+it('Can add extra args to query', async () => {
+    expect(selectFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1, username: 'svemat'}, 'ALLOW FILTERING')).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? ALLOW FILTERING', args: [1, 'svemat']});
+});

--- a/__tests__/raw/selectOneFromRaw.spec.ts
+++ b/__tests__/raw/selectOneFromRaw.spec.ts
@@ -1,0 +1,11 @@
+import { selectOneFromRaw } from '../../lib';
+
+// fix
+it('Can insert a user into the database', async () => {
+    expect(selectOneFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1, username: 'svemat'})).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? LIMIT 1', args: [1, 'svemat']});
+});
+
+
+it('Can add extra args to query', async () => {
+    expect(selectOneFromRaw<{'users': {uid: number, username: string}}, 'users'>('scyllo', 'users', '*', {uid: 1, username: 'svemat'}, 'ALLOW FILTERING')).toEqual({query: 'SELECT * FROM scyllo.users WHERE uid=? AND username=? LIMIT 1 ALLOW FILTERING', args: [1, 'svemat']});
+});

--- a/__tests__/raw/updateRaw.spec.ts
+++ b/__tests__/raw/updateRaw.spec.ts
@@ -3,3 +3,7 @@ import { updateRaw } from "../../lib"
 it('Can update a specific user in the database', async () => {
     expect(updateRaw<{'users': {uid: number, username: string}}, 'users', 'uid' | 'username'>('scyllo', 'users', { username: "Jest" }, { uid: 1234567890 })).toEqual({query: 'UPDATE scyllo.users SET username=? WHERE uid=?', args: ['Jest', 1234567890]});
 });
+
+it('Can add extra args to query', async () => {
+    expect(updateRaw<{'users': {uid: number, username: string}}, 'users', 'uid' | 'username'>('scyllo', 'users', { username: "Jest" }, { uid: 1234567890 }, 'ALLOW FILTERING')).toEqual({query: 'UPDATE scyllo.users SET username=? WHERE uid=? ALLOW FILTERING', args: ['Jest', 1234567890]});
+});

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -61,12 +61,13 @@ export const insertIntoRaw = <
         keyspace: string,
         table: F,
         obj: Partial<TableMap[F]>,
+        extra?: string,
     ): QueryBuild => ({
         query: `INSERT INTO ${keyspace}.${table} (${Object.keys(obj).join(
             ', ',
         )}) VALUES (${Object.keys(obj)
             .map(() => '?')
-            .join(', ')})`,
+            .join(', ')}) ${extra || ''}`,
         args: Object.values(obj).map(toScyllo),
     });
 
@@ -79,6 +80,7 @@ export const updateRaw = <
         table: TableName,
         obj: Partial<TableMap[TableName]>,
         criteria: { [key in ColumnName]?: TableMap[TableName][key] | string },
+        extra?: string,
     ): QueryBuild => ({
         query: `UPDATE ${keyspace}.${table} SET ${Object.keys(obj)
             .map((it) => it + '=?')
@@ -89,7 +91,7 @@ export const updateRaw = <
                   .map((crit) => (crit += '=?'))
                   .join(' AND ')
                 : ''
-        }`.trim(),
+        } ${extra || ''}`.trim(),
         args: [...Object.values(obj), ...(criteria ? Object.values(criteria) : [])],
     });
 

--- a/src/ScylloClient.ts
+++ b/src/ScylloClient.ts
@@ -187,9 +187,10 @@ export class ScylloClient<Tables extends TableScheme> {
      */
     async insertInto<Table extends keyof Tables>(
         table: Table,
-        obj: Partial<Tables[Table]>
+        obj: Partial<Tables[Table]>,
+        extra?: string
     ): Promise<types.ResultSet> {
-        const query = insertIntoRaw<Tables, Table>(this.keyspace, table, obj);
+        const query = insertIntoRaw<Tables, Table>(this.keyspace, table, obj, extra);
 
         return await this.query(query);
     }
@@ -200,13 +201,15 @@ export class ScylloClient<Tables extends TableScheme> {
     async update<Table extends keyof Tables, ColumnName extends keyof Tables[Table]>(
         table: Table,
         obj: Partial<Tables[Table]>,
-        criteria: { [key in ColumnName]?: Tables[Table][key] | string }
+        criteria: { [key in ColumnName]?: Tables[Table][key] | string },
+        extra?: string
     ): Promise<types.ResultSet> {
         const query = updateRaw<Tables, Table, ColumnName>(
             this.keyspace,
             table,
             obj,
-            criteria
+            criteria,
+            extra
         );
 
         return await this.query(query);


### PR DESCRIPTION
The `extra` argument is used to pass in extra options that should be passed along with the normal query to the database.

Closes #18 